### PR TITLE
Refactor the archive file interface and visibility of public members

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -64,25 +64,25 @@ struct Cli {
 }
 
 /// Runtime parameters, parsed, validated and ready to be used
-pub struct Params {
+pub(crate) struct Params {
     /// Which folder to backup
-    pub folder: PathBuf,
+    pub(crate) folder: PathBuf,
     /// An optional interval duration in seconds
-    pub interval: Option<u64>,
+    pub(crate) interval: Option<u64>,
     /// The optional name of the archive that will be uploaded to S3 (without extension)
-    pub filename: Option<String>,
+    pub(crate) filename: Option<String>,
     /// The AWS S3 region, defaults to us-east-1
-    pub aws_region: RegionProviderChain,
+    pub(crate) aws_region: RegionProviderChain,
     /// The AWS S3 bucket name
-    pub aws_bucket: String,
+    pub(crate) aws_bucket: String,
     /// The AWS S3 access key ID
-    pub aws_key_id: String,
+    pub(crate) aws_key_id: String,
     /// The AWS S3 access key
-    pub aws_key: String,
+    pub(crate) aws_key: String,
 }
 
 /// Parse the command-line arguments and environment variables into runtime params
-pub async fn parse_config() -> Result<Params> {
+pub(crate) async fn parse_config() -> Result<Params> {
     // Read from the command-line args, and if not present, check environment variables
     let params = Cli::parse();
 

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -3,7 +3,7 @@ use std::fmt;
 
 /// An alias for unwrap when the code has been audited to ensure that the value is not None/Err or when panic
 /// is required.
-pub trait OrPanic<T> {
+pub(crate) trait OrPanic<T> {
     /// An alias for unwrap when the code has been audited to ensure that the value is not None/Err or when panic
     /// is required.
     fn or_panic(self) -> T;


### PR DESCRIPTION
This new struct allows to keep a reference to the tempdir so that it doesn't get dropped prematurely (and thus deleted).
Changed the visibility of all pub members to pub(crate).