### PR TITLE
End-to-end testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v3
       - run: |
           rustup component add rustfmt clippy
-          cargo check
+          cargo check --locked
           cargo fmt --all -- --check
           cargo clippy -- -Dwarnings
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,6 +35,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-trait"
+version = "0.1.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cd7fce9ba8c3c042128ce72d8b2ddbf3a05747efb67ea0313c635e10bda47a2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -425,6 +436,7 @@ dependencies = [
  "aws-sdk-s3",
  "aws-smithy-http",
  "clap",
+ "dockertest",
  "dotenvy",
  "env_logger",
  "flate2",
@@ -434,6 +446,12 @@ dependencies = [
  "tokio",
  "uuid",
 ]
+
+[[package]]
+name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
@@ -463,6 +481,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "bollard"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d82e7850583ead5f8bbef247e2a3c37a19bd576e8420cd262a6711921827e1e5"
+dependencies = [
+ "base64 0.13.1",
+ "bollard-stubs",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "http",
+ "hyper",
+ "hyperlocal",
+ "log",
+ "pin-project-lite",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_urlencoded",
+ "thiserror",
+ "tokio",
+ "tokio-util",
+ "url",
+ "winapi",
+]
+
+[[package]]
+name = "bollard-stubs"
+version = "1.42.0-rc.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed59b5c00048f48d7af971b71f800fdf23e858844a6f9e4d32ca72e9399e7864"
+dependencies = [
+ "serde",
+ "serde_with",
 ]
 
 [[package]]
@@ -600,6 +656,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a01d95850c592940db9b8194bc39f4bc0e89dee5c4265e4b1807c34a9aba453c"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "859d65a907b6852c9361e3185c862aae7fafd2887876799fa55f5f99dc40d610"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -617,10 +708,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "dockertest"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce5e89cd7c59faf3cf0e31369fce2382807dd794d4fcce6380adcefdf5987796"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "base64 0.13.1",
+ "bollard",
+ "dyn-clone",
+ "futures",
+ "lazy_static",
+ "rand",
+ "secrecy",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "dotenvy"
 version = "0.15.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03d8c417d7a8cb362e0c37e5d815f5eb7c37f79ff93707329d5a194e42e54ca0"
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9b0705efd4599c15a38151f4721f7bc388306f61084d3bfd50bd07fbca5cb60"
 
 [[package]]
 name = "either"
@@ -721,12 +840,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13e2792b0ff0340399d58445b88fd9770e3489eff258a4cbc1523418f12abf84"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e5317663a9089767a1ec00a487df42e0ca174b61b4483213ac24448e4664df5"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -734,6 +869,23 @@ name = "futures-core"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec90ff4d0fe1f57d600049061dc6bb68ed03c7d2fbd697274c41805dcb3f8608"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8de0a35a6ab97ec8869e32a2473f4b1324459e14c29275d14b10cb1fd19b50e"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfb8371b6fb2aeb2d280374607aeabfc99d95c72edfe51692e42d3d7f0d08531"
 
 [[package]]
 name = "futures-macro"
@@ -764,9 +916,13 @@ version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c1d6de3acfef38d2be4b1f543f553131788603495be83da675e180c8d6b7bd1"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
  "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
  "slab",
@@ -823,6 +979,15 @@ name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "hermit-abi"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "hermit-abi"
@@ -925,6 +1090,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyperlocal"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fafdf7b2b2de7c9784f76e02c0935e65a8117ec3b768644379983ab333ac98c"
+dependencies = [
+ "futures-util",
+ "hex",
+ "hyper",
+ "pin-project",
+ "tokio",
+]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -969,7 +1153,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22e18b0a45d56fe973d6db23972bf5bc46f988a4a2385deac9cc29572f09daef"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.3.1",
  "io-lifetimes",
  "rustix",
  "windows-sys 0.45.0",
@@ -1007,6 +1191,16 @@ name = "linux-raw-sys"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
+
+[[package]]
+name = "lock_api"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
@@ -1073,6 +1267,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
+dependencies = [
+ "hermit-abi 0.2.6",
+ "libc",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1104,6 +1308,29 @@ name = "outref"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f222829ae9293e33a9f5e9f440c6760a3d450a64affe1846486b140db81c1f4"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-sys 0.45.0",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -1336,7 +1563,7 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b"
 dependencies = [
- "base64",
+ "base64 0.21.0",
 ]
 
 [[package]]
@@ -1355,6 +1582,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scopeguard"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
 name = "sct"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1362,6 +1595,15 @@ checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
 dependencies = [
  "ring",
  "untrusted",
+]
+
+[[package]]
+name = "secrecy"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
+dependencies = [
+ "zeroize",
 ]
 
 [[package]]
@@ -1425,6 +1667,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_with"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "678b5a069e50bf00ecd22d0cd8ddf7c236f68581b03db652061ed5eb13a312ff"
+dependencies = [
+ "serde",
+ "serde_with_macros",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e182d6ec6f05393cc0e5ed1bf81ad6db3a8feedf8ee515ecdd369809bcce8082"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1472,6 +1748,12 @@ checksum = "4614a76b2a8be0058caa9dbbaf66d988527d86d003c11a94fbd335d7661edcef"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "smallvec"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "socket2"
@@ -1610,6 +1892,8 @@ dependencies = [
  "libc",
  "memchr",
  "mio",
+ "num_cpus",
+ "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,9 @@ temp-dir = "0.1"
 tokio = { version = "1", features = ["rt", "macros", "signal"] }
 uuid = { version = "1", features = ["v4", "fast-rng"] }
 
+[dev-dependencies]
+dockertest = "0.3.1"
+
 [profile.release]
 lto = "thin"
 strip = true

--- a/src/aws.rs
+++ b/src/aws.rs
@@ -30,8 +30,10 @@ pub(crate) async fn upload_file(archive: Archive, params: &Params) -> Result<()>
     env::set_var("AWS_ACCESS_KEY_ID", &params.aws_key_id);
     env::set_var("AWS_SECRET_ACCESS_KEY", &params.aws_key);
     let mut shared_config_builder = aws_config::from_env().region(params.aws_region.region().await);
-    if cfg!(test) {
-        shared_config_builder = shared_config_builder.endpoint_url("http://localhost:9090")
+    // we set this special environment variable when doing e2e testing
+    if env::var("AWSBCK_TESTING_E2E").is_ok() {
+        warn!("Endpoint URL was changed to localhost while in testing environment.");
+        shared_config_builder = shared_config_builder.endpoint_url("http://127.0.0.1:9090")
     }
     let shared_config = shared_config_builder.load().await;
     let client = Client::new(&shared_config);

--- a/src/aws.rs
+++ b/src/aws.rs
@@ -29,10 +29,11 @@ pub(crate) async fn upload_file(archive: Archive, params: &Params) -> Result<()>
     // from the command line args
     env::set_var("AWS_ACCESS_KEY_ID", &params.aws_key_id);
     env::set_var("AWS_SECRET_ACCESS_KEY", &params.aws_key);
-    let shared_config = aws_config::from_env()
-        .region(params.aws_region.region().await) // set the region
-        .load()
-        .await;
+    let mut shared_config_builder = aws_config::from_env().region(params.aws_region.region().await);
+    if cfg!(test) {
+        shared_config_builder = shared_config_builder.endpoint_url("http://localhost:9090")
+    }
+    let shared_config = shared_config_builder.load().await;
     let client = Client::new(&shared_config);
     // if the desired filename was specified, append the file extension in case it was not already provided
     let filename = params

--- a/tests/e2e_test.rs
+++ b/tests/e2e_test.rs
@@ -1,0 +1,32 @@
+use std::{path::PathBuf, process::Command};
+
+use dockertest::{
+    waitfor::{MessageSource, MessageWait},
+    Composition, DockerTest, Source,
+};
+
+#[test]
+fn e2e_test() {
+    let mut test = DockerTest::new().with_default_source(Source::DockerHub);
+    let mut aws = Composition::with_repository("adobe/s3mock")
+        .with_container_name("aws")
+        .with_wait_for(Box::new(MessageWait {
+            message: "Started S3MockApplication".to_string(),
+            source: MessageSource::Stdout,
+            timeout: 10,
+        }));
+    aws.port_map(9090, 9090);
+    test.add_composition(aws);
+
+    test.run(|ops| async move {
+        let _container = ops.handle("aws");
+        let path = PathBuf::from(env!("CARGO_BIN_EXE_awsbck"));
+        let output = Command::new(path)
+            .args(["-b", "foo", "--id", "bar", "-k", "baz"])
+            .arg("./src")
+            .output()
+            .expect("Failed to execute command");
+        println!("{}", String::from_utf8_lossy(&output.stderr));
+        assert!(output.status.success());
+    });
+}

--- a/tests/e2e_test.rs
+++ b/tests/e2e_test.rs
@@ -1,4 +1,4 @@
-use std::{path::PathBuf, process::Command};
+use std::{collections::HashMap, path::PathBuf, process::Command};
 
 use dockertest::{
     waitfor::{MessageSource, MessageWait},
@@ -8,25 +8,29 @@ use dockertest::{
 #[test]
 fn e2e_test() {
     let mut test = DockerTest::new().with_default_source(Source::DockerHub);
+    let mut container_env = HashMap::new();
+    container_env.insert("initialBuckets".to_string(), "foo".to_string());
     let mut aws = Composition::with_repository("adobe/s3mock")
         .with_container_name("aws")
         .with_wait_for(Box::new(MessageWait {
             message: "Started S3MockApplication".to_string(),
             source: MessageSource::Stdout,
             timeout: 10,
-        }));
-    aws.port_map(9090, 9090);
+        }))
+        .with_env(container_env);
+    aws.port_map(9090, 9090).port_map(9191, 9191);
     test.add_composition(aws);
 
     test.run(|ops| async move {
         let _container = ops.handle("aws");
         let path = PathBuf::from(env!("CARGO_BIN_EXE_awsbck"));
         let output = Command::new(path)
+            .env("AWSBCK_TESTING_E2E", "1")
             .args(["-b", "foo", "--id", "bar", "-k", "baz"])
             .arg("./src")
             .output()
             .expect("Failed to execute command");
-        println!("{}", String::from_utf8_lossy(&output.stderr));
         assert!(output.status.success());
+        assert!(String::from_utf8_lossy(&output.stderr).contains("Backup succeeded"));
     });
 }

--- a/tests/e2e_test.rs
+++ b/tests/e2e_test.rs
@@ -1,5 +1,6 @@
-use std::{collections::HashMap, path::PathBuf, process::Command};
+use std::{collections::HashMap, env, path::PathBuf, process::Command};
 
+use aws_sdk_s3::Client;
 use dockertest::{
     waitfor::{MessageSource, MessageWait},
     Composition, DockerTest, Source,
@@ -7,24 +8,29 @@ use dockertest::{
 
 #[test]
 fn e2e_test() {
+    // start S3Mock container
     let mut test = DockerTest::new().with_default_source(Source::DockerHub);
     let mut container_env = HashMap::new();
+    // add default bucket "foo"
     container_env.insert("initialBuckets".to_string(), "foo".to_string());
     let mut aws = Composition::with_repository("adobe/s3mock")
         .with_container_name("aws")
         .with_wait_for(Box::new(MessageWait {
+            // wait until container has finished initializing
             message: "Started S3MockApplication".to_string(),
             source: MessageSource::Stdout,
             timeout: 10,
         }))
         .with_env(container_env);
-    aws.port_map(9090, 9090).port_map(9191, 9191);
+    // expose HTTP port
+    aws.port_map(9090, 9090);
     test.add_composition(aws);
 
-    test.run(|ops| async move {
-        let _container = ops.handle("aws");
+    test.run(|_ops| async move {
         let path = PathBuf::from(env!("CARGO_BIN_EXE_awsbck"));
-        let output = Command::new(path)
+
+        // upload with default archive name
+        let output = Command::new(&path)
             .env("AWSBCK_TESTING_E2E", "1")
             .args(["-b", "foo", "--id", "bar", "-k", "baz"])
             .arg("./src")
@@ -32,5 +38,36 @@ fn e2e_test() {
             .expect("Failed to execute command");
         assert!(output.status.success());
         assert!(String::from_utf8_lossy(&output.stderr).contains("Backup succeeded"));
+
+        // upload with custom archive name (including slash)
+        let output = Command::new(&path)
+            .env("AWSBCK_TESTING_E2E", "1")
+            .args(["-b", "foo", "--id", "bar", "-k", "baz", "-f", "test/test"])
+            .arg("./src")
+            .output()
+            .expect("Failed to execute command");
+        assert!(output.status.success());
+        assert!(String::from_utf8_lossy(&output.stderr).contains("Backup succeeded"));
+
+        // check bucket contents
+        env::set_var("AWS_ACCESS_KEY_ID", "bar");
+        env::set_var("AWS_SECRET_ACCESS_KEY", "baz");
+        let shared_config = aws_config::from_env()
+            .region("us-east-1")
+            .endpoint_url("http://127.0.0.1:9090")
+            .load()
+            .await;
+        let client = Client::new(&shared_config);
+        let resp = client.list_objects_v2().bucket("foo").send().await.unwrap();
+        let objects: Vec<_> = resp
+            .contents()
+            .unwrap_or_default()
+            .iter()
+            .map(|o| o.key().unwrap_or_default())
+            .collect();
+        let mut sizes_iter = resp.contents().unwrap_or_default().iter().map(|o| o.size());
+
+        assert_eq!(objects, vec!["awsbck_src.tar.gz", "test/test.tar.gz"]);
+        assert!(sizes_iter.all(|s| s > 0));
     });
 }

--- a/tests/e2e_test.rs
+++ b/tests/e2e_test.rs
@@ -68,6 +68,6 @@ fn e2e_test() {
         let mut sizes_iter = resp.contents().unwrap_or_default().iter().map(|o| o.size());
 
         assert_eq!(objects, vec!["awsbck_src.tar.gz", "test/test.tar.gz"]);
-        assert!(sizes_iter.all(|s| s > 0));
+        assert!(sizes_iter.all(|s| s > 1000));
     });
 }

--- a/tests/e2e_test.rs
+++ b/tests/e2e_test.rs
@@ -65,9 +65,14 @@ fn e2e_test() {
             .iter()
             .map(|o| o.key().unwrap_or_default())
             .collect();
-        let mut sizes_iter = resp.contents().unwrap_or_default().iter().map(|o| o.size());
+        let all_sizes = resp
+            .contents()
+            .unwrap_or_default()
+            .iter()
+            .map(|o| o.size())
+            .all(|s| s > 1000);
 
         assert_eq!(objects, vec!["awsbck_src.tar.gz", "test/test.tar.gz"]);
-        assert!(sizes_iter.all(|s| s > 1000));
+        assert!(all_sizes);
     });
 }


### PR DESCRIPTION
The [dockertest](https://crates.io/crates/dockertest) crate is used to spin up a docker container running [S3Mock](https://github.com/adobe/S3Mock).

Closes https://github.com/beeb/awsbck/issues/13