### PR TITLE
Sanitize default filename

### DIFF
--- a/src/aws.rs
+++ b/src/aws.rs
@@ -14,7 +14,10 @@ use aws_sdk_s3::{
 use aws_smithy_http::byte_stream::Length;
 use log::*;
 
-use crate::{backup::Archive, config::Params};
+use crate::{
+    backup::Archive,
+    config::{sanitize_filename, Params},
+};
 
 /// In bytes, minimum chunk size of 5MB. Increase CHUNK_SIZE to send larger chunks.
 const CHUNK_SIZE: u64 = 1024 * 1024 * 5;
@@ -52,7 +55,7 @@ pub(crate) async fn upload_file(archive: Archive, params: &Params) -> Result<()>
                 params
                     .folder
                     .file_name()
-                    .map(|f| f.to_string_lossy().to_string())
+                    .map(|f| sanitize_filename(f.to_string_lossy().to_string()))
                     .unwrap_or("backup".to_string())
             )
         });

--- a/src/aws.rs
+++ b/src/aws.rs
@@ -50,14 +50,12 @@ pub(crate) async fn upload_file(archive: Archive, params: &Params) -> Result<()>
         })
         .unwrap_or_else(|| {
             // default filename is awsbck_ + the folder name + .tar.gz
-            format!(
-                "awsbck_{}.tar.gz",
-                params
-                    .folder
-                    .file_name()
-                    .map(|f| sanitize_filename(f.to_string_lossy().to_string()))
-                    .unwrap_or("backup".to_string())
-            )
+            let sanitized_folder_name = params
+                .folder
+                .file_name()
+                .map(|f| sanitize_filename(f.to_string_lossy().to_string()))
+                .unwrap_or("backup".to_string());
+            format!("awsbck_{sanitized_folder_name}.tar.gz")
         });
     let multipart_upload_res: CreateMultipartUploadOutput = client
         .create_multipart_upload()

--- a/src/config.rs
+++ b/src/config.rs
@@ -118,7 +118,7 @@ pub(crate) async fn parse_config() -> Result<Params> {
 }
 
 /// Only keep recommended chars for S3 object keys and truncate to 1000 chars
-fn sanitize_filename(filename: impl Into<String>) -> String {
+pub(crate) fn sanitize_filename(filename: impl Into<String>) -> String {
     let mut filename: String = filename.into();
     // remove invalid characters
     filename.retain(|c| c.is_ascii_alphanumeric() || VALID_FILENAME_CHARS.contains(c));


### PR DESCRIPTION
The default filename includes the name of directory being backed up, so it needs to be sanitized.