### PR TITLE
Breaking: add cron scheduling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -435,7 +444,9 @@ dependencies = [
  "aws-config",
  "aws-sdk-s3",
  "aws-smithy-http",
+ "chrono",
  "clap",
+ "cron",
  "dockertest",
  "dotenvy",
  "env_logger",
@@ -557,6 +568,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "chrono"
+version = "0.4.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b0a3d9ed01224b22057780a37bb8c5dbfe1be8ba48678e7bf57ec4b385411f"
+dependencies = [
+ "iana-time-zone",
+ "num-integer",
+ "num-traits",
+ "winapi",
+]
+
+[[package]]
 name = "clap"
 version = "4.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -591,6 +614,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "350b9cf31731f9957399229e9b2adc51eeabdfbe9d71d9a0552275fd12710d09"
 dependencies = [
  "os_str_bytes",
+]
+
+[[package]]
+name = "codespan-reporting"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
+dependencies = [
+ "termcolor",
+ "unicode-width",
 ]
 
 [[package]]
@@ -637,6 +670,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "cron"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ff76b51e4c068c52bfd2866e1567bee7c567ae8f24ada09fd4307019e25eab7"
+dependencies = [
+ "chrono",
+ "nom",
+ "once_cell",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -652,6 +696,50 @@ version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d2301688392eb071b0bf1a37be05c469d3cc4dbbd95df672fe28ab021e6a096"
 dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "cxx"
+version = "1.0.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a140f260e6f3f79013b8bfc65e7ce630c9ab4388c6a89c71e07226f49487b72"
+dependencies = [
+ "cc",
+ "cxxbridge-flags",
+ "cxxbridge-macro",
+ "link-cplusplus",
+]
+
+[[package]]
+name = "cxx-build"
+version = "1.0.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da6383f459341ea689374bf0a42979739dc421874f112ff26f829b8040b8e613"
+dependencies = [
+ "cc",
+ "codespan-reporting",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "scratch",
+ "syn",
+]
+
+[[package]]
+name = "cxxbridge-flags"
+version = "1.0.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90201c1a650e95ccff1c8c0bb5a343213bdd317c6e600a93075bca2eff54ec97"
+
+[[package]]
+name = "cxxbridge-macro"
+version = "1.0.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b75aed41bb2e6367cae39e6326ef817a851db13c13e4f3263714ca3cfb8de56"
+dependencies = [
+ "proc-macro2",
  "quote",
  "syn",
 ]
@@ -1104,6 +1192,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64c122667b287044802d6ce17ee2ddf13207ed924c712de9a66a5814d5b64765"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "winapi",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0703ae284fc167426161c2e3f1da3ea71d94b21bedbcc9494e92b28e334e3dca"
+dependencies = [
+ "cxx",
+ "cxx-build",
+]
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1188,6 +1300,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
+name = "link-cplusplus"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecd207c9c713c34f95a097a5b029ac2ce6010530c7b49d7fea24d977dede04f5"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1228,6 +1349,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1246,6 +1373,16 @@ dependencies = [
  "log",
  "wasi",
  "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -1587,6 +1724,12 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "scratch"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1792db035ce95be60c3f8853017b3999209281c24e2ba5bc8e59bf97a0c590c1"
 
 [[package]]
 name = "sct"
@@ -2033,6 +2176,12 @@ checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,9 @@ anyhow = "1"
 aws-config = "0.54"
 aws-sdk-s3 = "0.24"
 aws-smithy-http = "0.54"
+chrono = { version = "0.4", default-features = false, features = ["clock"] }
 clap = { version = "4", features = ["derive", "env"] }
+cron = "0.12"
 dotenvy = "0.15"
 env_logger = "0.10"
 flate2 = "1"

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ Options:
 
 CLI arguments take precedence over environment variables.
 
+The cron expression is parsed by the [`cron`](https://github.com/zslayton/cron) crate, the first item describes seconds.
+
 The `--filename` option accepts ASCII alphanumeric characters and `!-_.*'()/`. Other characters will be discarded.
 
 ### Example

--- a/README.md
+++ b/README.md
@@ -33,14 +33,14 @@ Arguments:
   <FOLDER>  Path to the folder to backup [env: AWSBCK_FOLDER=]
 
 Options:
-  -i, --interval <SECONDS>  Specify an interval in seconds to run the backup periodically [env: AWSBCK_INTERVAL=]
-  -f, --filename <NAME>     The name of the archive that will be uploaded to S3, without extension (optional) [env: AWSBCK_FILENAME=]
-  -r, --region <REGION>     The AWS S3 region [env: AWS_REGION=] [default: us-east-1]
-  -b, --bucket <BUCKET>     The AWS S3 bucket name [env: AWS_BUCKET=]
-      --id <KEY_ID>         The AWS S3 access key ID [env: AWS_ACCESS_KEY_ID=]
-  -k, --key <KEY>           The AWS S3 secret access key [env: AWS_SECRET_ACCESS_KEY=]
-  -h, --help                Print help (see more with '--help')
-  -V, --version             Print version
+  -c, --cron <EXPR>      Specify a cron espression to run the backup on a schedule [env: AWSBCK_CRON=]
+  -f, --filename <NAME>  The name of the archive that will be uploaded to S3, without extension (optional) [env: AWSBCK_FILENAME=]
+  -r, --region <REGION>  The AWS S3 region [env: AWS_REGION=] [default: us-east-1]
+  -b, --bucket <BUCKET>  The AWS S3 bucket name [env: AWS_BUCKET=]
+      --id <KEY_ID>      The AWS S3 access key ID [env: AWS_ACCESS_KEY_ID=]
+  -k, --key <KEY>        The AWS S3 secret access key [env: AWS_SECRET_ACCESS_KEY=]
+  -h, --help             Print help (see more with '--help')
+  -V, --version          Print version
 ```
 
 CLI arguments take precedence over environment variables.
@@ -56,7 +56,7 @@ AWS_REGION="eu-central-1"
 AWS_ACCESS_KEY_ID="YOUR_KEY_ID"
 AWS_SECRET_ACCESS_KEY="yoursecret"
 
-$ awsbck -i 3600 -b my_bucket /my_folder
+$ awsbck -c "@hourly" -b my_bucket /my_folder
 ```
 
 ### Docker example
@@ -70,7 +70,7 @@ $ docker run \
   --mount type=bind,src="$(pwd)"/target,dst=/target,readonly \
   -e AWS_REGION -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY \
   vbersier/awsbck:latest \
-  -i 3600 -b my_bucket /target
+  -c "15 */10 * * * *" -b my_bucket /target
 ```
 
 ## Installation
@@ -134,7 +134,7 @@ services:
         '-c',
         'while true; do sleep 21600; docker exec -t postgres pg_dumpall -c -U postgres > /backup/dump_database.sql; done'
       ]
-  # we mount the backup volume as read-only and back up the SQL dump every 24h
+  # we mount the backup volume as read-only and back up the SQL dump daily at 3.12am
   awsbck:
     image: vbersier/awsbck:latest
     restart: unless-stopped
@@ -145,7 +145,7 @@ services:
         read_only: true
     environment:
       AWSBCK_FOLDER: /database
-      AWSBCK_INTERVAL: 86400
+      AWSBCK_CRON: '0 12 3 * * * *'
       AWS_REGION: eu-central-1
       AWS_BUCKET: my_bucket
       AWS_ACCESS_KEY_ID: $AWS_ACCESS_KEY_ID

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,12 +3,16 @@
 #![warn(clippy::unwrap_used)]
 #![warn(clippy::expect_used)]
 
-use std::{env, sync::Arc, time::Duration};
+use std::{env, sync::Arc};
 
 use anyhow::{anyhow, Context, Result};
+use chrono::Utc;
 use dotenvy::dotenv;
 use log::*;
-use tokio::{task, time};
+use tokio::{
+    task,
+    time::{self, Instant},
+};
 
 use backup::backup;
 use config::parse_config;
@@ -37,18 +41,31 @@ async fn main() -> Result<()> {
     let params = Arc::new(parse_config().await?);
 
     // check if we run the backup once, or periodically forever
-    match params.interval {
-        Some(interval) => {
+    match &params.schedule {
+        Some(schedule) => {
             info!(
-                "Will backup \"{}\" every {interval} seconds",
-                params.folder.to_string_lossy()
+                "Will backup \"{}\" on cron schedule: \"{}\"",
+                params.folder.to_string_lossy(),
+                schedule.to_string()
             );
             // spawn a routine that will run the backup periodically
             let task = task::spawn(async move {
                 let shared_params = Arc::clone(&params);
-                let mut interval = time::interval(Duration::from_secs(interval));
+                //let mut interval = time::interval(Duration::from_secs(interval));
                 loop {
-                    interval.tick().await; // the first tick completes immediately, triggering the backup
+                    let Some(deadline) = shared_params.schedule.as_ref().or_panic().upcoming(Utc).next() else {
+                        error!("Could not get next execution time for cron schedule");
+                        return;
+                    };
+                    let Ok(wait_time) = (deadline - Utc::now()).to_std() else {
+                        error!("Could not convert duration to std Duration");
+                        return;
+                    };
+                    let Some(deadline) = Instant::now().checked_add(wait_time) else {
+                        error!("Could not convert deadline to tokio Instant");
+                        return;
+                    };
+                    time::sleep_until(deadline).await;
                     match backup(&shared_params).await {
                         Ok(_) => {
                             info!("Backup succeeded");

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,7 +51,6 @@ async fn main() -> Result<()> {
             // spawn a routine that will run the backup periodically
             let task = task::spawn(async move {
                 let shared_params = Arc::clone(&params);
-                //let mut interval = time::interval(Duration::from_secs(interval));
                 loop {
                     let Some(deadline) = shared_params.schedule.as_ref().or_panic().upcoming(Utc).next() else {
                         error!("Could not get next execution time for cron schedule");

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,6 +52,7 @@ async fn main() -> Result<()> {
             let task = task::spawn(async move {
                 let shared_params = Arc::clone(&params);
                 loop {
+                    // we checked that the schedule exists above, so we can unwrap it
                     let Some(deadline) = shared_params.schedule.as_ref().or_panic().upcoming(Utc).next() else {
                         error!("Could not get next execution time for cron schedule");
                         return;

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,6 +57,7 @@ async fn main() -> Result<()> {
                         error!("Could not get next execution time for cron schedule");
                         return;
                     };
+                    info!("Next backup scheduled for {}", deadline.to_rfc2822());
                     let Ok(wait_time) = (deadline - Utc::now()).to_std() else {
                         error!("Could not convert duration to std Duration");
                         return;


### PR DESCRIPTION
This PR introduces a new feature to define periodic backups using cron expressions instead of an interval in seconds.

This offers more flexibility. The new option is available through the `-c` or `--cron` CLI arguments, as well as the `AWSBCK_CRON` environment variable.

The old `-i`/`--interval` option and `AWSBCK_INTERVAL` are not supported anymore.
To perform backup based on an interval, use for instance `-c "@hourly"`, `-c "@daily"` or `-c "0 0 */6 * * * *"`.

