### PR TITLE
ci: use official action for github app token

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -16,7 +16,7 @@ jobs:
     environment: Cargo
     steps:
       - name: Generate GitHub token
-        uses: tibdex/github-app-token@v2
+        uses: actions/create-github-app-token@v1
         id: generate-token
         with:
           app_id: ${{ secrets.APP_ID }}


### PR DESCRIPTION
[Official docs](https://release-plz.ieni.dev/docs/github/token) have changed to now use the official github app to generate the token.